### PR TITLE
Update compileSdkVersion and targetSdkVersion

### DIFF
--- a/RNRangeSlider.podspec
+++ b/RNRangeSlider.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "RNRangeSlider"
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = "MIT"
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "8.0"
+
+  s.source       = { :git => "https://github.com/githuboftigran/rn-range-slider.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+  s.requires_arc = true
+
+  s.dependency 'React'
+end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,21 +5,21 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.4.0'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion = "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion = "28.0.0"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
     }
     lintOptions {
         abortOnError false


### PR DESCRIPTION
This PR solves an error when trying to build release APK using `./gradlew assembleRelease` by having it target API 28. It will be compatible with future Android X migration also.

It might be a breaking change, so you might want to modify your release number.