### PR TITLE
Fix ViewPropTypes warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import React, { memo, useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Animated, PanResponder, View, ViewPropTypes } from 'react-native';
+import { Animated, PanResponder, View } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 
 import styles from './styles';

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/githuboftigran/rn-range-slider.git"
   },
   "dependencies": {
+    "deprecated-react-native-prop-types": "^2.3.0"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
After upgrading to React Native 0.68, I started seeing this warning: `ViewPropTypes will be removed from React Native. Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types'.`

Personally, I don't love the suggested solution, but I don't know what the alternative is (I asked about better alternatives [here](https://github.com/facebook/react-native/issues/33557#issuecomment-1126951163)).

I based this PR off of [a similar PR for react-native-maps](https://github.com/react-native-maps/react-native-maps/pull/4096).

It's unfortunate that this fix requires adding the first and only dependency to this package, but without adding `deprecated-react-native-prop-types` to `dependencies`, anyone who wants to use this package would need to have their own copy of `deprecated-react-native-prop-types` installed, which would be annoying.