### PR TITLE
Tap to change slider position

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const handleValueChange = useCallback((low, high) => {
 
 ...
 
-<Slider
+<RangeSlider
   style={styles.slider}
   min={0}
   max={100}


### PR DESCRIPTION
### Motivation

Based on guidelines for some popular design sistems the tap-to-change functionality is an important feature of a slider:
 
- [Material Design Slider specs ](https://m3.material.io/components/sliders/specs)
- [Microsoft's Fluent Design Slider](https://learn.microsoft.com/en-us/fluent-ui/web-components/components/slider?pivots=typescript)
- [Adobe React Spectrum Slider](https://react-spectrum.adobe.com/react-spectrum/Slider.html)

### Approach
In order to add the tap-to-change functionality I used the `onTouchEnd` View event. Not sure how suitable this event is, I couldn't find any downsides of not using it. Let me know if you think there's a better event to be used.

### Fixes #115

